### PR TITLE
build,Makefile: add default Vivado SDK path to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 #PATH=$PATH:/opt/Xilinx/SDK/2015.4/gnu/arm/lin/bin
 
-CROSS_COMPILE ?= arm-linux-gnueabihf-
-VIVADO_SETTINGS ?= /opt/Xilinx/Vivado/2018.2/settings64.sh
+VIVADO_VERSION ?= 2018.2
+VIVADO_TOOLCHAIN_PATH ?= /opt/Xilinx/SDK/$(VIVADO_VERSION)/gnu/aarch32/lin/gcc-arm-linux-gnueabi
+CROSS_COMPILE ?= $(VIVADO_TOOLCHAIN_PATH)/bin/arm-linux-gnueabihf-
+VIVADO_SETTINGS ?= /opt/Xilinx/Vivado/$(VIVADO_VERSION)/settings64.sh
 XSDK_SETTINGS ?= ${VIVADO_SETTINGS}
 
 NCORES = $(shell nproc)
@@ -75,7 +77,7 @@ buildroot/output/images/rootfs.cpio.gz:
 	make -C buildroot legal-info
 	scripts/legal_info_html.sh "M2k" "$(CURDIR)/buildroot/board/m2k/VERSIONS"
 	cp build/LICENSE.html buildroot/board/m2k/msd/LICENSE.html
-	make -C buildroot TOOLCHAIN_EXTERNAL_INSTALL_DIR= ARCH=arm CROSS_COMPILE=$(CROSS_COMPILE) BUSYBOX_CONFIG_FILE=$(CURDIR)/buildroot/board/m2k/busybox-1.25.0.config all
+	make -C buildroot TOOLCHAIN_EXTERNAL_INSTALL_DIR=$(VIVADO_TOOLCHAIN_PATH) ARCH=arm CROSS_COMPILE=$(CROSS_COMPILE) BUSYBOX_CONFIG_FILE=$(CURDIR)/buildroot/board/m2k/busybox-1.25.0.config all
 
 .PHONY: buildroot/output/images/rootfs.cpio.gz
 


### PR DESCRIPTION
And parametrize the Vivado release version.

Usually, the usecase is to use the default /opt/Xilinx path.
This change also passes the Vivado SDK path (for the compiler) to buildroot
so that it builds.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>