### PR TITLE
build: tweak defaults to run 'make' without Vivado

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,17 @@
 #PATH=$PATH:/opt/Xilinx/SDK/2015.4/gnu/arm/lin/bin
 
 VIVADO_VERSION ?= 2019.1
-VIVADO_TOOLCHAIN_PATH ?= /opt/Xilinx/SDK/$(VIVADO_VERSION)/gnu/aarch32/lin/gcc-arm-linux-gnueabi
-CROSS_COMPILE ?= $(VIVADO_TOOLCHAIN_PATH)/bin/arm-linux-gnueabihf-
 VIVADO_SETTINGS ?= /opt/Xilinx/Vivado/$(VIVADO_VERSION)/settings64.sh
 XSDK_SETTINGS ?= ${VIVADO_SETTINGS}
 
 HAVE_VIVADO= $(shell bash -c "source $(VIVADO_SETTINGS) > /dev/null 2>&1 && vivado -version > /dev/null 2>&1 && echo 1 || echo 0")
+
+ifeq (1, ${HAVE_VIVADO})
+VIVADO_TOOLCHAIN_PATH ?= /opt/Xilinx/SDK/$(VIVADO_VERSION)/gnu/aarch32/lin/gcc-arm-linux-gnueabi
+CROSS_COMPILE ?= $(VIVADO_TOOLCHAIN_PATH)/bin/arm-linux-gnueabihf-
+else
+CROSS_COMPILE ?= arm-linux-gnueabihf-
+endif
 
 NCORES = $(shell nproc)
 VSUBDIRS = hdl buildroot linux u-boot-xlnx


### PR DESCRIPTION
Without this change, building the m2k-fw is possible, but it requires
manually overriding the CROSS_COMPILE variable.

With this, just running 'make' is sufficient if Vivado isn't installed.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>